### PR TITLE
Cinnamon Theme - Update to use spacing & cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ VOLUME /opt/oomox-gtk-theme/test_results
 ENTRYPOINT /bin/bash
 
 # App dependensies:
-RUN echo "Update arch deps - 2" && \
+RUN echo "Update arch deps - 0" && \
+    echo -e 'Server = http://mirrors.evowise.com/archlinux/$repo/os/$arch\nServer = http://mirror.koddos.net/archlinux/$repo/os/$arch\nServer = https://mirror.i3d.net/pub/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist && \
     pacman -Syu --noconfirm && \
     pacman -S --needed --noconfirm bash grep sed bc glib2 gdk-pixbuf2 sassc gtk-engine-murrine gtk-engines gtk3 make
 

--- a/src/cinnamon/scss/_extends.scss
+++ b/src/cinnamon/scss/_extends.scss
@@ -134,9 +134,10 @@
 }
 
 // used in selectors
-// .osd-window, .info-osd, .info-osd
+// .osd-window, .info-osd, .workspace-osd
 %osd-shared {
     @extend %bg-grad-to-bottom;
+
     border: 1px solid $exterior_border;
     border-radius: $roundness;
     color: $dark_fg_color;
@@ -172,7 +173,8 @@
 // #menu-search-entry, .run-dialog-entry, #notification StEntry
 %dialog-entry {
     @extend %tooltip-bg-grad-to-top;
-    padding: 2px;
+
+    padding: $spacing_plus2;
     border-radius: $roundness;
     color: $tooltip_fg_color;
     border: 1px solid $interior_border;
@@ -188,10 +190,11 @@
 // used in selectors
 // .desklet-with-borders, .desklet-with-borders-and-header, .desklet-header, .photoframe-box
 %desklet-shared {
-    color: $dark_fg_color;
-    padding: 10px;
-    border: 1px solid $exterior_border;
     @extend %bg-grad-to-right;
+
+    color: $dark_fg_color;
+    padding: 8px;
+    border: 1px solid $exterior_border;
 }
 
 // used in selectors
@@ -206,9 +209,10 @@
 // used in selectors
 // .notification-button, .notification-icon-button, .modal-dialog-button, .sound-player-overlay StButton, .keyboard-key
 %shared-button {
+    @extend %button-bg-grad-to-top;
+
     border: 1px solid $button_border;
     border-radius: $roundness;
-    @extend %button-bg-grad-to-top;
     text-align: center;
     color: $button_fg_color;
     transition-duration: 150;
@@ -218,6 +222,7 @@
 // .notification-button:hover, .notification-icon-button:hover, .modal-dialog-button:hover, .sound-player-overlay StButton:hover, .keyboard-key:hover
 %shared-button-hover {
     @extend %hover-button-bg-grad-to-top;
+
     border: 1px solid $selected_border;
 }
 
@@ -225,24 +230,37 @@
 // .notification-button:active, .notification-icon-button:active, .modal-dialog-button:active, .modal-dialog-button:pressed, .sound-player-overlay StButton:active, .keyboard-key:active
 %shared-button-active {
     @extend %selected-bg-grad-to-bottom;
+
     color: $selected_fg_color;
 }
 
 // used in selectors
-// .menu, .popup-menu
-%menu-width {
-    min-width: 100px;
-    margin: 0.4em;
+// .menu .popup-combo-menu
+%shared-menu {
+    @extend %bg-grad-to-right;
+
+    padding: 8px;
+    border: 1px solid $exterior_border;
+    border-radius: $roundness;
+    color: $dark_fg_color;
 }
 
 // used in selectors
-// .menu, .popup-menu, .popup-combo-menu
-%shared-menu {
-    padding: 10px;
-    border: 1px solid $exterior_border;
-    border-radius: $roundness;
-    @extend %bg-grad-to-right;
-    color: $dark_fg_color;
+// .menu-application-button-label, .menu-category-button-label
+%menu-button-label-shared {
+    &:ltr {
+        padding-left: 4px;
+    }
+    &:rtl {
+        padding-right: 4px;
+    }
+}
+
+// used in selectors
+// .popup-menu-item, .popup-combobox-item, .menu-favorites-button, .menu-places-button, .menu-category-button, .menu-category-button-greyed, .menu-category-button-selected
+%menu-buttons-shared {
+	//min-height: 22px; //setting a min height accross the board for all menu types (menu entries with an application icon are hardcoded to this min-height) causes display issues in cinnamon :-(
+    padding: $spacing_plus2;
 }
 
 // used in selectors
@@ -273,24 +291,27 @@
 // used in selectors
 // .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu
 %menu-context-shared {
-    padding: 5px;
-    margin: 0.5em 0;
+    @extend %bg-grad-to-bottom;
+
+    padding: 8px;
+    margin: 8px 0;
     border-radius: $roundness;
     border: 1px solid $interior_border;
-    @extend %bg-grad-to-bottom;
-}
-
-// used in selectors
-// .starkmenu-favorites-box StScrollView .menu-context-menu StBoxLayout >.popup-menu-item, .menu-favorites-box StScrollView .menu-context-menu StBoxLayout >.popup-menu-item
-%menu-context-shared-workaround {
-    margin: 0;
-    padding: .5em .7em;
+        StIcon {
+            &:ltr {
+			    padding-right: 4px;
+            }
+            &:rtl {
+			    padding-left: 4px;
+            }
+        }
 }
 
 // used in selectors
 // .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus
 %panel-top-shared {
     @extend %selected-bg-grad-to-top;
+
     color: $selected_fg_color;
 }
 
@@ -298,6 +319,7 @@
 // .panel-bottom .windows-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus
 %panel-bottom-shared {
     @extend %selected-bg-grad-to-bottom;
+
     color: $selected_fg_color;
 }
 
@@ -305,6 +327,7 @@
 // .panel-left .window-list-item-box:active, .panel-left .window-list-item-box:checked, .panel-left .window-list-item-box:focus
 %panel-left-shared {
     @extend %selected-bg-grad-to-left;
+
     color: $selected_fg_color;
 }
 
@@ -312,14 +335,8 @@
 // .panel-right .windows-list-item-box:active, .panel-right .window-list-item-box:checked, .panel-right .window-list-item-box:focus
 %panel-right-shared {
     @extend %selected-bg-grad-to-right;
-    color: $selected_fg_color;
-}
 
-// used in selectors
-// .panel-top .workspace-switcher, .panel-bottom .workspace-switcher
-%workspace-switcher-shared {
-    padding-left: 2px;
-    padding-right: 2px;
+    color: $selected_fg_color;
 }
 
 // used in selectors

--- a/src/cinnamon/scss/_global.scss
+++ b/src/cinnamon/scss/_global.scss
@@ -77,3 +77,8 @@ $info_bg_color: #%TERMINAL_COLOR12%;
 
 // used for border-radius throughout theme
 $roundness: %ROUNDNESS%px;
+
+// used for buttons, entrys, panel spacing, and menu item spacing.
+$spacing: %SPACING%px;
+$spacing_plus2: (%SPACING% + 2) + px;
+

--- a/src/cinnamon/scss/sections/_accessibility.scss
+++ b/src/cinnamon/scss/sections/_accessibility.scss
@@ -3,9 +3,8 @@
     background-color: $dark_bg_color_trans;
 }
 .keyboard-key {
-    min-height: 1.5em;
-    min-width: 2.5em;
     @extend %shared-button;
+
     &:grayed {
         color: $selected_fg_color;
         border-color: $selected_fg_color;
@@ -21,22 +20,22 @@
     }
 }
 .keyboard-layout {
-    spacing: 10px;
-    padding: 10px;
+    spacing: 8px;
+    padding: 8px;
 }
 .keyboard-row {
-    spacing: 15px;
+    spacing: 16px;
 }
 .keyboard-subkeys {
     color: $dark_fg_color;
-    padding: 5px;
+    padding: 4px;
     -arrow-border-radius: $roundness;
     -arrow-background-color: $dark_bg_color;
     -arrow-border-width: 1px;
     -arrow-border-color: $dark_fg_color;
-    -arrow-base: 20px;
-    -arrow-rise: 10px;
-    -boxpointer-gap: 5px;
+    -arrow-base: 16px;
+    -arrow-rise: 8px;
+    -boxpointer-gap: 4px;
 }
 // desktop zoom feature
 .magnifier-zoom-region {

--- a/src/cinnamon/scss/sections/_alt-tab.scss
+++ b/src/cinnamon/scss/sections/_alt-tab.scss
@@ -5,19 +5,17 @@
 }
 .switcher-list {
     @extend %bg-grad-to-bottom;
+
     border-radius: $roundness;
     border: 1px solid $exterior_border;
-    padding: 20px;
+    padding: 16px;
     color: $dark_fg_color;
     .item-box {
         padding: 8px;
         border-radius: $roundness;
-        &:outlined {
-            padding: 6px;
-            border: 1px solid $interior_border;
-        }
         &:selected {
             @extend %selected-bg-grad-to-bottom;
+
             color: $selected_fg_color;
         }
     }

--- a/src/cinnamon/scss/sections/_calendar.scss
+++ b/src/cinnamon/scss/sections/_calendar.scss
@@ -16,6 +16,7 @@
 }
 .calendar-change-month-back {
     @extend %calendar-shared;
+
     border: 1px solid transparent;
     background-image: url(assets/calendar-arrow-left.svg);
     &:rtl {
@@ -30,6 +31,7 @@
 }
 .calendar-change-month-forward {
     @extend %calendar-shared;
+
     border: 1px solid transparent;
     background-image: url(assets/calendar-arrow-right.svg);
     &:rtl {
@@ -99,6 +101,7 @@
 // this is always is an active state
 .calendar-today {
     @extend %selected-bg-grad-to-bottom;
+
     font-weight: bold;
     &:active {
         color: $selected_fg_color;

--- a/src/cinnamon/scss/sections/_desklets.scss
+++ b/src/cinnamon/scss/sections/_desklets.scss
@@ -1,7 +1,7 @@
 // desklets - the base .desklet selector is for 'undecorated' desklets however some subtle background themeing is desirable
 // to maintain visibility irrespctive of wallpaper and to allow for the highlighting scheme to work
 .desklet {
-    padding: 10px;
+    padding: 8px;
     color: $dark_fg_color;
     border-radius: $roundness;
     background-color: $dark_bg_color_trans;
@@ -12,6 +12,7 @@
 // these do not inherit from .desklet
 .desklet-with-borders {
     @extend %desklet-shared;
+
     border-radius: $roundness;
     &:highlight {
         background-color: $selected_bg_color;
@@ -19,6 +20,7 @@
 }
 .desklet-with-borders-and-header {
     @extend %desklet-shared;
+
     border-radius-bottomleft: $roundness;
     border-radius-bottomright: $roundness;
     &:highlight {
@@ -27,6 +29,7 @@
 }
 .desklet-header {
     @extend %desklet-shared;
+
     font-size: 1.2em;
     border-radius-topleft: $roundness;
     border-radius-topright: $roundness;
@@ -36,6 +39,7 @@
 }
 .photoframe-box {
     @extend %desklet-shared;
+
     border-radius: $roundness;
     &:highlight {
         background-color: $selected_bg_color;

--- a/src/cinnamon/scss/sections/_dialogs.scss
+++ b/src/cinnamon/scss/sections/_dialogs.scss
@@ -1,25 +1,26 @@
 // on screen messages and input boxes
 .modal-dialog {
+    @extend %bg-grad-to-right;
+
     border: 1px solid $exterior_border;
     border-radius: $roundness;
-    @extend %bg-grad-to-right;
     color: $dark_fg_color;
-    padding: 20px 30px;
+    padding: 16px 20px;
 }
 .modal-dialog-button-box {
-    spacing: 21px;
+    spacing: 16px;
 }
 .modal-dialog-button {
     @extend %shared-button;
-    margin-left: 10px;
-    margin-right: 10px;
-    padding: 4px 32px 5px;
+
+    min-width: 5em;
+    min-height: 1em;
+    padding: $spacing_plus2;
     &:hover {
         @extend %shared-button-hover;
     }
     &:focus {
         color: $selected_fg_color;
-        padding: 3px 31px 4px;
     }
     &:active {
         @extend %shared-button-active;
@@ -48,13 +49,14 @@
 }
 .run-dialog-entry {
         @extend %dialog-entry;
+
         &:focus  {
             border: 1px solid $selected_border;
         }
 }
 .run-dialog {
     border-radius: $roundness;
-    padding: 15px 20px;
+    padding: 16px 20px;
 }
 // removable media dialogs
 .cinnamon-mount-operation-icon {
@@ -71,24 +73,28 @@
 }
 .show-processes-dialog-subject {
     @extend %shared-dialogs-subject;
+
     &:rtl {
         @extend %shared-dialogs-subject-rtl;
     }
 }
 .mount-question-dialog-subject {
     @extend %shared-dialogs-subject;
+
     &:rtl {
         @extend %shared-dialogs-subject-rtl;
     }
 }
 .show-processes-dialog-description {
     @extend %shared-dialogs-description;
+
     &:rtl {
         padding-right: 17px;
     }
 }
 .mount-question-dialog-description {
     @extend %shared-dialogs-description;
+
     &:rtl {
         padding-right: 17px;
     }
@@ -128,8 +134,9 @@
 // displayed when media keys are pressed.
 .osd-window {
     @extend %osd-shared;
-    padding: 20px;
+
     spacing: 1em;
+    padding: 16px;
     .level {
         height: 0.7em;
         border-radius: 0.3em;
@@ -140,17 +147,12 @@
         background-color: $scrollbar_slider_hover_color;
     }
 }
-.info-osd {
+.info-osd, .workspace-osd {
     @extend %osd-shared;
+
     font-size: 1.5em;
-    padding: 20px;
     text-align: center;
-}
-// displays when switching workspace via keyboard shortcuts
-.workspace-osd {
-    @extend %osd-shared;
-    padding: 10px;
-    font-size: 1.2em;
+    padding: 8px 10px;
 }
 // this is an full screen overlay that is displayed with any cinnamon OSD or modal dialog which needs to always be semi transparent
 .lightbox {
@@ -190,8 +192,9 @@
 // dialog box for the cinnamon debug utility
 #LookingGlassDialog {
     @extend %bg-grad-to-bottom;
+
     spacing: 4px;
-    padding: 10px;
+    padding: 8px;
     border: 1px solid $exterior_border;
     border-radius: $roundness;
     color: $dark_fg_color;

--- a/src/cinnamon/scss/sections/_menu.scss
+++ b/src/cinnamon/scss/sections/_menu.scss
@@ -1,20 +1,8 @@
-// popup-menu-boxpointer is only for cinnamon < version 3.2
-.popup-menu-boxpointer {
-    -arrow-border-radius: $roundness;
-    -arrow-background-color: $dark_bg_color;
-    -arrow-border-width: 1px;
-    -arrow-border-color: $exterior_border;
-    -arrow-base: 24px;
-    -arrow-rise: 11px;
-}
 .menu {
-    @extend %menu-width;
     @extend %shared-menu;
-}
-// popup-menu is only for cinnamon < version 3.2
-.popup-menu {
-    @extend %menu-width;
-    @extend %shared-menu;
+
+    min-width: 100px;
+    margin: 4px;
 }
 // scale view right click menu
 .popup-combo-menu {
@@ -26,16 +14,11 @@
 // applet submenus
 .popup-sub-menu {
     @extend %bg-grad-to-bottom;
+
     border: 1px solid $interior_border;
     border-radius: $roundness;
-    padding: 5px;
-    margin: 0.5em 0;
-    .popup-menu-item {
-        &:ltr {
-        }
-        &:rtl {
-        }
-    }
+    padding: 8px;
+    margin: 8px 0;
     StScrollBar {
         padding: 2px;
         min-width: 0.8em;
@@ -60,8 +43,8 @@
 }
 // individual menu entries are themed here
 .popup-menu-item {
-    padding: .5em .7em;
-    spacing: 1em;
+    @extend %menu-buttons-shared;
+
     color: $dark_fg_color;
     &:active {
         background-color: $selected_bg_color;
@@ -76,11 +59,12 @@
     color: $dark_fg_color;
 }
 .popup-combobox-item {
-    spacing: 1em;
+    @extend %menu-buttons-shared;
 }
 // sliders and separators in menus
 .popup-separator-menu-item {
     @extend %separator-shared;
+
     -gradient-direction: horizontal;
 }
 .popup-slider-menu-item {
@@ -98,6 +82,7 @@
 }
 .popup-menu-icon {
     icon-size: 1.14em;
+    padding: 0px 4px;
 }
 .popup-menu-item-dot {
 }
@@ -128,60 +113,53 @@
     icon-size: 1.14em;
 }
 // all the remaining code is for the main menu applet
-// it includes some themeing to ensure constency in right click context menu behavior in third party menu applets.
 .menu-favorites-box {
-    padding: 10px;
+    @extend %bg-grad-to-right;
+
+    padding: 8px;
     border: 1px solid $interior_border;
     border-radius: $roundness;
-    @extend %bg-grad-to-right;
     transition-duration: 150;
-    StScrollView .menu-context-menu StBoxLayout > .popup-menu-item {
-        @extend %menu-context-shared-workaround;
-    }
 }
 .menu-favorites-button {
-    padding: .5em .7em;
+    @extend %menu-buttons-shared;
+
     &:hover {
         background-color: $selected_bg_color;
         border-radius: $roundness;
         color: $selected_fg_color;
     }
 }
-.menu-places-box {
-    padding: 10px;
-    border: 1px solid $interior_border;
-    border-radius: $roundness;
-    @extend %bg-grad-to-right;
-}
-.menu-places-button {
-    padding: .5em .7em;
-}
 .menu-categories-box {
-    padding: 10px;
+    padding: 8px;
 }
 .menu-applications-inner-box {
-    padding: 10px;
+    @extend %bg-grad-to-right;
+
+    padding: 8px;
     border-radius: $roundness;
     border: 1px solid $interior_border;
-    @extend %bg-grad-to-right;
     StScrollView {
         @extend %menu-context-shared;
     }
 }
 .menu-applications-outer-box {
-    padding: 10px;
+    @extend %bg-grad-to-right;
+
+    padding: 8px;
     border: 1px solid $interior_border;
     border-radius: $roundness;
-    @extend %bg-grad-to-right;
 }
 .menu-application-button {
-    padding: .5em .7em;
+    @extend %menu-buttons-shared;
+
     &:highlighted {
         font-weight: bold;
     }
 }
 .menu-application-button-selected {
-    padding: .5em .7em;
+    @extend %menu-buttons-shared;
+
     background-color: $selected_bg_color;
     border-radius: $roundness;
     color: $selected_fg_color;
@@ -190,23 +168,20 @@
     }
 }
 .menu-application-button-label {
-    &:ltr {
-        padding-left: 5px;
-    }
-    &:rtl {
-        padding-right: 5px;
-    }
+    @extend %menu-button-label-shared;
 }
 .menu-category-button {
-    padding: .5em .7em;
+	@extend %menu-buttons-shared;
 }
 .menu-category-button-greyed {
-    padding: .5em .7em;
+    @extend %menu-buttons-shared;
+
     color: $dark_fg_color;
     font-style: italic;
 }
 .menu-category-button-selected {
-    padding: .5em .7em;
+    @extend %menu-buttons-shared;
+
     background-color: $selected_bg_color;
     border-radius: $roundness;
     color: $selected_fg_color;
@@ -214,26 +189,24 @@
     }
 }
 .menu-category-button-label {
-    &:ltr {
-        padding-left: 5px;
-    }
-    &:rtl {
-        padding-right: 5px;
-    }
+    @extend %menu-button-label-shared;
 }
 // in the stock menu app descriptions are shown at the base of the menu
 .menu-selected-app-box {
-    padding: .25em .5em;
+    padding: 8px;
+    margin-bottom: 4px;
     text-align: right;
-    height: 2.5em;
     &:rtl {
+        text-align: left;
     }
 }
 .menu-selected-app-title {
     font-weight: bold;
+    font-size: 0.8em;
 }
 .menu-selected-app-description {
     max-width: 150px;
+    font-size: 0.8em;
 }
 // the menus search box
 .menu-search-box {
@@ -250,6 +223,7 @@
 }
 #menu-search-entry {
     @extend %dialog-entry;
+
     margin: 0.5em 0;
     &:focus {
         border: 1px solid $selected_border;
@@ -262,11 +236,6 @@
     color: $tooltip_fg_color;
 }
 // cinnVIIstark menu right click favourites context menu
-.starkmenu-favorites-box {
-    .menu-context-menu {
+.starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
         @extend %menu-context-shared;
-    }
-    StScrollView .menu-context-menu StBoxLayout > .popup-menu-item {
-        @extend %menu-context-shared-workaround;
-    }
 }

--- a/src/cinnamon/scss/sections/_notifications.scss
+++ b/src/cinnamon/scss/sections/_notifications.scss
@@ -1,8 +1,9 @@
 // notification system
 #notification {
+    @extend %bg-grad-to-right;
+
     border-radius: $roundness;
     border: 1px solid $exterior_border;
-    @extend %bg-grad-to-right;
     padding: 8px;
     spacing-rows: 5px;
     spacing-columns: 10px;
@@ -15,9 +16,13 @@
     }
     StEntry {
         @extend %dialog-entry;
+
         &:focus {
             border: 1px solid $selected_border;
         }
+    }
+    .url-highlighter {
+        link-color: $link_color;
     }
 }
 .notification-with-image {
@@ -42,21 +47,23 @@
     }
 }
 #notification-body {
-    spacing: 5px;
+    spacing: 4px;
 }
 #notification-actions {
-    spacing: 10px;
+    spacing: 8px;
 }
 .notification-button {
     @extend %shared-button;
+
     border-radius: $roundness;
-    padding: 4px 8px 5px;
+    min-width: 5em;
+    min-height: 1em;
+    padding: $spacing_plus2;
     &:hover {
         @extend %shared-button-hover;
     }
     &:focus {
         color: $selected_fg_color;
-        padding: 3px 8px 4px;
     }
     &:active {
         @extend %shared-button-active;
@@ -64,19 +71,21 @@
 }
 .notification-icon-button {
     @extend %shared-button;
+
     border-radius: $roundness;
-    padding: 5px;
+    min-width: 2em;
+    min-height: 2em;
+    padding: $spacing_plus2;
     &:hover {
         @extend %shared-button-hover;
     }
     &:focus {
         color: $selected_fg_color;
-        padding: 4px;
     }
     &:active {
         @extend %shared-button-active;
     }
     > StIcon {
-        icon-size: 3.5em;
+        icon-size: 1.5em;
     }
 }

--- a/src/cinnamon/scss/sections/_overview.scss
+++ b/src/cinnamon/scss/sections/_overview.scss
@@ -2,15 +2,6 @@
 #overview {
     spacing: 12px;
 }
-.workspace-controls {
-    visible-height: 3em;
-}
-.workspace-thumbnails-background {
-    padding: 10px;
-    border: 1px solid $exterior_border;
-    border-radius: $roundness;
-    @extend %bg-grad-to-right;
-}
 .workspace-thumbnails {
     spacing: 14px;
 }
@@ -46,19 +37,17 @@
 .workspace-overview-background-shade {
     background-color: $dark_bg_color_trans;
 }
-.workspace-thumbnail-indicator {
-    border: 2px solid $exterior_border;
-}
 .window-caption {
-    padding: 10px;
+    @extend %bg-grad-to-bottom;
+
+    padding: 4px 6px;
     border: 1px solid $exterior_border;
     border-radius: $roundness;
-    @extend %bg-grad-to-bottom;
-    padding: 2px 8px;
     color: $dark_fg_color;
     -cinnamon-caption-spacing: 4px;
     &#selected {
         @extend %selected-bg-grad-to-bottom;
+
         color: $selected_fg_color;
     }
 }
@@ -91,19 +80,19 @@
     }
 }
 .expo-workspaces-name-entry {
-    padding: 10px;
+    @extend %bg-grad-to-bottom;
+
+    padding: 4px 6px;
     border: 1px solid $exterior_border;
     border-radius: $roundness;
-    @extend %bg-grad-to-bottom;
     selected-color: $selected_fg_color;
     selection-background-color: $selected_bg_color;
     color: $dark_fg_color;
-    min-width: 10em;
-    height: 1.5em;
     text-align: center;
     &#selected {
-        color: $selected_fg_color;
         @extend %selected-bg-grad-to-bottom;
+
+        color: $selected_fg_color;
         selected-color: $dark_fg_color;
         selection-background-color: $selected_bg_color;
         border: 1px solid $selected_border;

--- a/src/cinnamon/scss/sections/_panel.scss
+++ b/src/cinnamon/scss/sections/_panel.scss
@@ -71,38 +71,43 @@
 // do not overlap the panel border
 .panel-top {
     @extend %bg-grad-to-bottom;
+
     border-bottom: 1px solid;
     border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-top;
+
         &:hover {
             @extend %hover-bg-grad-to-top;
         }
         &:active {
             @extend %panel-top-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-top;
                 }
         }
         &:checked {
             @extend %panel-top-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-top;
-                }            
+                }
         }
         &:focus {
             @extend %panel-top-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-top;
                 }
         }
     }
-    .workspace-switcher {
-        @extend %workspace-switcher-shared;
+    .workspace-switcher, .workspace-graph {
+        padding: 1px $spacing;
     }
     .applet-box {
-        padding: 1px 3px;
-        margin-bottom: 2px;
+        padding: 1px $spacing;
+        margin-bottom: 1px;
     }
     .applet-label {
     }
@@ -110,41 +115,49 @@
         border-bottom: 2px solid;
         border-color: $selected_border;
     }
+    .applet-separator {
+        padding: 3px $spacing;
+    }
 }
 .panel-bottom {
     @extend %bg-grad-to-top;
+
     border-top: 1px solid;
     border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-bottom;
+
         &:hover {
             @extend %hover-bg-grad-to-bottom;
         }
         &:active {
             @extend %panel-bottom-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-bottom;
-                }            
+                }
         }
         &:checked {
             @extend %panel-bottom-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-bottom;
-                }           
+                }
         }
         &:focus {
             @extend %panel-bottom-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-bottom;
                 }
         }
     }
-    .workspace-switcher {
-        @extend %workspace-switcher-shared;
+    .workspace-switcher, .workspace-graph {
+        padding: 1px $spacing;
     }
     .applet-box {
-        padding: 1px 3px;
-        margin-top: 2px;
+        padding: 1px $spacing;
+        margin-top: 1px;
     }
     .applet-label {
     }
@@ -152,67 +165,81 @@
         border-top: 2px solid;
         border-color: $selected_border;
     }
+    .applet-separator {
+        padding: 3px $spacing;
+    }
 }
 .panel-left {
     @extend %bg-grad-to-right;
+
     border-right: 1px solid;
     border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-left;
-        margin-right: 1px;
+
         &:hover {
             @extend %hover-bg-grad-to-left;
         }
         &:active {
             @extend %panel-left-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-left;
                 }
         }
         &:checked {
             @extend %panel-left-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-left;
                 }
         }
         &:focus {
             @extend %panel-left-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-left;
                 }
         }
     }
-    .applet-box {
-        padding: 3px 1px;
-        margin-right: 2px;
+    .workspace-switcher, .workspace-graph {
+        padding: $spacing 1px;
     }
-    .workspace-switcher.panel-right .workspace-switcher {
-        padding-top: 3px;
-        padding-bottom: 3px;
+    .applet-box {
+        padding: $spacing 1px;
+        margin-right: 1px;
+    }
+    .applet-label {
     }
     .panel-launchers .launcher:hover {
         border-right: 3px solid;
         border-color: $selected_border;
     }
+    .applet-separator {
+        padding: $spacing 3px;
+    }
 }
 .panel-right {
     @extend %bg-grad-to-left;
+
     border-left: 1px solid;
     border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-right;
-        margin-left: 2px;
+
         &:hover {
             @extend %hover-bg-grad-to-right;
         }
         &:active {
             @extend %panel-right-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-right;
                 }
         }
         &:checked {
             @extend %panel-right-shared;
+
             &:hover {
                 @extend %hover-selected-grad-to-right;
                 }
@@ -224,13 +251,21 @@
                 }
         }
     }
+    .workspace-switcher, .workspace-graph {
+        padding: $spacing 1px;
+    }
     .applet-box {
-        padding: 3px 1px;
-        margin-left: 2px;
+        padding: $spacing 1px;
+        margin-left: 1px;
+    }
+    .applet-label {
     }
     .panel-launchers .launcher:hover {
         border-left: 3px solid;
         border-color: $selected_border;
+    }
+    .applet-separator {
+        padding: $spacing 3px;
     }
 }
 // a non feature - not worth themeing
@@ -242,54 +277,7 @@
     &:focus {
     }
 }
-#appMenu {
-    spacing: 4px;
-}
-.panel-button {
-    -natural-hpadding: 6px;
-    -minimum-hpadding: 2px;
-    font-weight: bold;
-    color: $dark_fg_color;
-    transition-duration: 150;
-    #appMenuIcon {
-        app-icon-bottom-clip: 1px;
-    }
-    &:active {
-        #appMenuIcon {
-            app-icon-bottom-clip: 2px;
-        }
-        > .system-status-icon {
-            icon-shadow: black 0 2px 2px;
-        }
-    }
-    &:checked {
-        #appMenuIcon {
-            app-icon-bottom-clip: 2px;
-        }
-        > .system-status-icon {
-            icon-shadow: black 0 2px 2px;
-        }
-    }
-    &:focus {
-        #appMenuIcon {
-            app-icon-bottom-clip: 2px;
-        }
-        > .system-status-icon {
-            icon-shadow: black 0 2px 2px;
-        }
-    }
-    &:hover {
-        color: $selected_bg_color;
-    }
-    &:overview {
-    }
-}
-.panel-menu {
-}
 // remaining code is for panel items starting with the generic applets
-.applet-separator {
-    padding: 5px 4px;
-}
 .applet-separator-line {
     width: 2px;
     background: $selected_bg_color;
@@ -329,11 +317,12 @@
     font-weight: bold;
     color: $dark_fg_color;
 }
+// icon-size set to 22 to match hard-coded menu icon size - applet-icon style is used for search provider results in menu
 .applet-icon {
     color: $dark_fg_color;
-    icon-size: 1.14em;
     padding: 0;
     spacing: 0;
+    icon-size: 22px;
 }
 // used by power applet to warn of low battery
 .system-status-icon {
@@ -347,9 +336,10 @@
         color: $error_color;
     }
 }
+// possibily deprecated - referenced in keyboard applet only
 .panel-status-button {
-    -natural-hpadding: 3px;
-    -minimum-hpadding: 3px;
+    -natural-hpadding: $spacing;
+    -minimum-hpadding: $spacing;
     font-weight: bold;
     color: $dark_fg_color;
     height: 2em;
@@ -371,11 +361,11 @@
 }
 // the window list applet. Some third party applets inherit some of this theming.
 .window-list-box {
-    spacing: 3px;
-    padding: 3px 10px;
+    spacing: $spacing;
+    padding: 1px 3px;
     &.vertical {
-        spacing: 3px;
-        padding: 10px 3px;
+        spacing: $spacing;
+        padding: 3px 1px;
     }
     #appMenuIcon {
         padding: 1px;
@@ -408,6 +398,7 @@
 // cinnamon 3.8 will support an improved window-list-thumbnail preview which now has it's own selector
 .window-list-preview {
     @extend %bg-grad-to-right;
+
     border-radius: $roundness;
     border: 1px solid $exterior_border;
     padding: 10px 15px;
@@ -417,14 +408,14 @@
 // the sound player applet
 .sound-player {
     StButton {
-        width: 18px;
-        height: 18px;
-        padding: 5px;
+        min-width: 2em;
+        min-height: 2em;
+        padding: $spacing_plus2;
         color: $button_fg_color;
         &:small {
-            width: 16px;
-            height: 16px;
-            padding: 1px;
+            min-width: 1.5em;
+            min-height: 1.5em;
+            padding: $spacing;
             StIcon {
                 icon-size: 1em;
             }
@@ -451,13 +442,15 @@
     background: rgba(0,0,0,0.2);
 }
 .sound-player-overlay {
+    @extend %bg-grad-to-bottom;
+
     width: 300px;
     padding: 12px 16px;
     spacing: 0.5em;
-    @extend %bg-grad-to-bottom;
     color: $dark_fg_color;
     StButton {
         @extend %shared-button;
+
         border-radius: $roundness;
         padding: 8px;
         &:hover {
@@ -493,14 +486,14 @@
 }
 // workspace switcher applet graph view
 .workspace-graph {
-    padding: 2px;
-    spacing: 2px;
     .workspace {
-        border: 1px solid $interior_border;
         @extend %bg-grad-to-bottom;
+
+        border: 1px solid $interior_border;
         &:active {
-            border: 1px solid $interior_border;
             @extend %selected-bg-grad-to-bottom;
+
+            border: 1px solid $interior_border;
             .windows {
                 -active-window-background: rgba(255, 255, 255, 0.8);
                 -active-window-border: rgba(0, 0, 0, 0.9);
@@ -519,10 +512,10 @@
 // most panel launcher themeing is orientation specific
 .panel-launchers {
     padding: 1px 4px;
-    spacing: 4px;
+    spacing: $spacing;
     &.vertical {
         padding: 4px 1px;
-        spacing: 4px;
+        spacing: $spacing;
         .launcher .icon-box {
             padding-top: 0;
         }
@@ -535,7 +528,7 @@
     max-height: 100px;
 }
 .systray {
-    spacing: 3px;
+    spacing: 4px;
 }
 .flashspot {
     background-color: $selected_bg_color;

--- a/src/cinnamon/scss/sections/_stage.scss
+++ b/src/cinnamon/scss/sections/_stage.scss
@@ -6,7 +6,7 @@ stage {
 }
 .cinnamon-link {
     color: $link_color;
-    text-decoration: underline;
+    font-style: italic;
     &:hover {
         color: $selected_fg_color;
     }
@@ -48,18 +48,6 @@ StScrollView {
     StScrollBar {
         min-width: 0.8em;
         min-height: 0.8em;
-    }
-    &.menu-context-menu {
-        border-width: 0;
-        padding: 0;
-        StBoxLayout {
-            @extend %bg-grad-to-bottom;
-            padding: 5px;
-                > .popup-menu-item {
-                    margin: .2em 0;
-                    padding: .3em .7em;
-                }
-        }
     }
 }
 .separator {
@@ -118,6 +106,7 @@ StScrollView {
 }
 #Tooltip {
     @extend %tooltip-bg-grad-to-top;
+
     padding: 5px 8px;
     color: $tooltip_fg_color;
     text-align: center;

--- a/src/cinnamon/scss/sections/_tile-hud.scss
+++ b/src/cinnamon/scss/sections/_tile-hud.scss
@@ -1,12 +1,14 @@
 // on screen preview of windows tiling placement
 .tile-preview {
     @extend %tile-shared;
+
     &.snap {
         @extend %tile-shared-snap;
     }
 }
 .tile-hud {
     @extend %tile-shared;
+
     &.snap {
         @extend %tile-shared-snap;
     }


### PR DESCRIPTION
* use spacing var in menu, panel, buttons and entries
* reviewed other hard-coded padding / spacing / margins
* clean up selectors confirmed as deprecated
* removed obsolete cinnamenu workarounds
* code style - ensure @extend commands are first