### PR TITLE
Metacity - use normal geometry for modal-dialogs

### DIFF
--- a/src/metacity-1/metacity-theme-2.xml
+++ b/src/metacity-1/metacity-theme-2.xml
@@ -1074,7 +1074,7 @@
 	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="modal_dialog_focused" geometry="modal">
+<frame_style name="modal_dialog_focused" geometry="normal">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
 	<piece position="titlebar" draw_ops="titlebar_attached_focused" />
 	<piece position="title" draw_ops="title_focused" />
@@ -1107,7 +1107,7 @@
 	<button function="unstick" state="normal"><draw_ops></draw_ops></button><button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="modal_dialog_unfocused" geometry="modal">
+<frame_style name="modal_dialog_unfocused" geometry="normal">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />

--- a/src/metacity-1/metacity-theme-3.xml
+++ b/src/metacity-1/metacity-theme-3.xml
@@ -1086,7 +1086,7 @@
 	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="modal_dialog_focused" geometry="modal">
+<frame_style name="modal_dialog_focused" geometry="normal">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
 	<piece position="titlebar" draw_ops="titlebar_attached_focused" />
 	<piece position="title" draw_ops="title_focused" />
@@ -1119,7 +1119,7 @@
 	<button function="unstick" state="normal"><draw_ops></draw_ops></button><button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="modal_dialog_unfocused" geometry="modal">
+<frame_style name="modal_dialog_unfocused" geometry="normal">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />


### PR DESCRIPTION
This fixes useless title-bars in child windows (file dialogs and preferences dialogs) in various applications in Mate and Cinnamon Desktop environments.
